### PR TITLE
remove LocalMiddleware

### DIFF
--- a/src/therapytracker/settings.py
+++ b/src/therapytracker/settings.py
@@ -47,7 +47,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
 ]
 
 ROOT_URLCONF = "therapytracker.urls"


### PR DESCRIPTION
If you need only one language, then do not put 'django.middleware.locale.LocaleMiddleware' in `settings.py`

'django.middleware.locale.LocaleMiddleware' is an option when there are multiple languages to choose from, depending on the browser/region/prefered language of browser.